### PR TITLE
change servers

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -18,10 +18,8 @@ from collections import deque
 DEFAULT_PORTS = {'t':'50001', 's':'50002', 'h':'8081', 'g':'8082'}
 
 DEFAULT_SERVERS = {
-    'electrum-verge.xyz':{'t':'50001', 's':'50002'},
+    'elec2.verge-blockchain.com':{'t':'50001', 's':'50002'},
     'electrum-xvg.stream':{'t':'50001', 's':'50002'},
-    'electrum-xvg.party':{'t':'50001', 's':'50002'},
-
 }
 
 NODES_RETRY_INTERVAL = 60


### PR DESCRIPTION
Default xyz doesn't work so added a new one that does. electrum-xvg.stream port 80 works, but cannot sync so I left it. .party domain refuses connections, removed. 