### PR TITLE
avoid crash if path .electrum-xvg not existing

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -467,5 +467,5 @@ class StoreDict(dict):
             dict.pop(self, key)
             self.save()
 
-
-sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')
+if os.path.exists(user_dir()):
+    sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')


### PR DESCRIPTION
always crash on startup without directory .electrum-xvg:

    sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')
IOError: [Errno 2] No such file or directory: '/home/user/.electrum-xvg/log.txt'