### PR TITLE
Ensure path to log file exists

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -466,6 +466,12 @@ class StoreDict(dict):
         if key in self.keys():
             dict.pop(self, key)
             self.save()
-
-
+            
+try:
+   os.makedirs(user_dir())
+except OSError as exc:
+   if exc.errno == errno.EEXIST and os.path.isdir(user_dir()):
+        pass
+   else:
+        raise
 sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')


### PR DESCRIPTION
Don't crash if no user_dir() doesn't exist try to make it instead.

If we move to Python 3 we can exist_ok instead of try/catch.