### PR TITLE
If userdir doesn't exist make it, don't crash

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -467,5 +467,9 @@ class StoreDict(dict):
             dict.pop(self, key)
             self.save()
 
-
+try:
+    os.makedirs(user_dir())
+except (IOError, OSError) as exception:
+    if exception.errno != errno.EEXIST:
+        raise
 sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,4 +1,4 @@
-ELECTRUM_VERSION = "2.4.1"    # version of the client package
+ELECTRUM_VERSION = "2.4.2"    # version of the client package
 PROTOCOL_VERSION = '0.10'   # protocol version requested
 NEW_SEED_VERSION = 11       # electrum versions >= 2.0
 OLD_SEED_VERSION = 4        # electrum versions < 2.0


### PR DESCRIPTION
Better than current PR as this wont skip making a log file if user_dir doesn't exist but actually makes one.

No longer crashes, makes directory and continues. Raises error if some over issue arises.

We should use exists_ok if we switch to python3