### PR TITLE
logfile error on install

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -468,4 +468,4 @@ class StoreDict(dict):
             self.save()
 
 
-sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')
+#sys.stdout = sys.stderr = open(os.path.join(user_dir(), 'log.txt'), 'w')


### PR DESCRIPTION
The .electrum directory doesn't exists when trying to create this log file. It was preventing install / Ubuntu 17.