### PR TITLE
fix wrong address prefix of the multi-signature wallet

### DIFF
--- a/lib/account.py
+++ b/lib/account.py
@@ -391,7 +391,7 @@ class Multisig_Account(BIP32_Account):
 
     def pubkeys_to_address(self, pubkeys):
         redeem_script = Transaction.multisig_script(sorted(pubkeys), self.m)
-        address = hash_160_to_bc_address(hash_160(redeem_script.decode('hex')), 5)
+        address = hash_160_to_bc_address(hash_160(redeem_script.decode('hex')), 33)
         return address
 
     def get_address(self, for_change, n):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -224,7 +224,7 @@ class Commands:
         """Create multisig address"""
         assert isinstance(pubkeys, list), (type(num), type(pubkeys))
         redeem_script = Transaction.multisig_script(pubkeys, num)
-        address = hash_160_to_bc_address(hash_160(redeem_script.decode('hex')), 5)
+        address = hash_160_to_bc_address(hash_160(redeem_script.decode('hex')), 33)
         return {'address':address, 'redeemScript':redeem_script}
 
     @command('w')

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -392,7 +392,7 @@ def parse_scriptSig(d, bytes):
     d['x_pubkeys'] = x_pubkeys
     d['pubkeys'] = pubkeys
     d['redeemScript'] = redeemScript
-    d['address'] = hash_160_to_bc_address(hash_160(redeemScript.decode('hex')), 5)
+    d['address'] = hash_160_to_bc_address(hash_160(redeemScript.decode('hex')), 33)
 
 
 
@@ -415,7 +415,7 @@ def get_address_from_output_script(bytes):
     # p2sh
     match = [ opcodes.OP_HASH160, opcodes.OP_PUSHDATA4, opcodes.OP_EQUAL ]
     if match_decoded(decoded, match):
-        return 'address', hash_160_to_bc_address(decoded[1][1],5)
+        return 'address', hash_160_to_bc_address(decoded[1][1],33)
 
     return 'script', bytes
 

--- a/plugins/btchipwallet.py
+++ b/plugins/btchipwallet.py
@@ -382,7 +382,7 @@ class BTChipWallet(BIP32_HD_Wallet):
                 if not self.canAlternateCoinVersions:
                     v, h = bc_address_to_hash_160(address)
                     if v == 48:
-                        output = hash_160_to_bc_address(h, 0)
+                        output = hash_160_to_bc_address(h, 30)
                 outputAmount = amount
 
         self.get_client() # prompt for the PIN before displaying the dialog if necessary


### PR DESCRIPTION
I found that the multi-signature P2SH addresses from a Electrom-XVG wallet cannot be used in any wallet including the Electrom-XVG itself.

![wrong-p2sh-address-type](https://user-images.githubusercontent.com/26923506/55858026-3515e380-5ba1-11e9-8ad1-684c18e9bbd5.jpg)
![cannot-send-to-these-addresses](https://user-images.githubusercontent.com/26923506/55858048-419a3c00-5ba1-11e9-8408-7425670dd8d6.jpg)

After reading the code, I found this in `lib/bitcoin.py`:
```
def is_address(addr):
    ADDRESS_RE = re.compile('[1-9A-HJ-NP-Za-km-z]{26,}\\Z')
    if not ADDRESS_RE.match(addr):
        return False
    try:
        addrtype, h = bc_address_to_hash_160(addr)
    except Exception:
        return False
    if addrtype not in [30, 33]:
        return False
    return addr == hash_160_to_bc_address(h, addrtype)
```

This shows that the prefix byte can only be 30 and 33. However, when encoding an address:

```
address = hash_160_to_bc_address(hash_160(redeem_script.decode('hex')), 5)
```

The addrtype `5` (B2SH prefix for bitcoin) seems wrong and should be `33`.

So I made a change and it looks fine. More tests are in progress (such as whether the transaction can be received and sent normally).